### PR TITLE
회원 계정 관련 기본 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# 환경 설정 파일
+.env
+
+# 운영 환경 설정 파일 무시
+application-prod.properties
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,25 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/learnhive/lessonservice/LessonServiceApplication.java
+++ b/src/main/java/com/learnhive/lessonservice/LessonServiceApplication.java
@@ -1,8 +1,10 @@
-package com.learnhive.lesson_service;
+package com.learnhive.lessonservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LessonServiceApplication {
 

--- a/src/main/java/com/learnhive/lessonservice/auth/AuthenticatedUserService.java
+++ b/src/main/java/com/learnhive/lessonservice/auth/AuthenticatedUserService.java
@@ -1,0 +1,33 @@
+package com.learnhive.lessonservice.auth;
+
+import com.learnhive.lessonservice.domain.UserAccount;
+import com.learnhive.lessonservice.exception.CustomException;
+import com.learnhive.lessonservice.exception.ExceptionCode;
+import com.learnhive.lessonservice.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthenticatedUserService {
+
+    private final UserAccountRepository userRepository;
+
+    public UserAccount getAuthenticatedUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ExceptionCode.UNAUTHORIZED_USER);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails) {
+            String username = ((UserDetails) principal).getUsername();
+            return userRepository.findByUsername(username)
+                    .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        }
+        throw new CustomException(ExceptionCode.UNAUTHORIZED_USER);
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/learnhive/lessonservice/auth/CustomUserDetailsService.java
@@ -1,0 +1,41 @@
+package com.learnhive.lessonservice.auth;
+
+import com.learnhive.lessonservice.domain.UserAccount;
+import com.learnhive.lessonservice.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserAccount userAccount = userAccountRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("가입한 사용자명이 없습니다: " + username));
+
+        // 계정이 삭제되었는지 확인 (soft delete 처리된 계정 차단)
+        if (userAccount.isDeleted()) {
+            throw new UsernameNotFoundException("해당 계정은 삭제된 상태입니다: " + username);
+        }
+//
+//        // roles 필드를 SimpleGrantedAuthority 로 변환
+//        List<GrantedAuthority> authorities = userAccount.getRoles().stream()
+//                .map(role -> new SimpleGrantedAuthority("ROLE_" + role)) // ROLE_ 붙여서 권한 생성
+//                .collect(Collectors.toList());
+
+        return new User(
+                userAccount.getUsername(),
+                userAccount.getUserPassword(),
+                Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/learnhive/lessonservice/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.learnhive.lessonservice.auth;
+
+import com.learnhive.lessonservice.service.JwtBlacklistService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenManager jwtTokenManager;
+    private final UserDetailsService userDetailsService;
+    private final JwtBlacklistService jwtBlacklistService;
+    private final TokenProperties tokenProperties;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && jwtTokenManager.validateToken(token) && !jwtBlacklistService.isTokenBlacklisted(token)) {
+            String username = jwtTokenManager.getUsernameFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        // HTTP 헤더에서 추출 시도
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        // 헤더에 토큰이 없으면 쿠키에서 추출
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (tokenProperties.getCookieName().equals(cookie.getName())) {
+                    return cookie.getValue(); // 쿠키에서 oi_token 반환
+                }
+            }
+            logger.warn("No matching cookie found with the given name.");
+        } else {
+            logger.warn("No cookie found in the request.");
+        }
+
+        // 토큰을 찾을 수 없는 경우 null 반환
+        return null;
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/auth/JwtTokenManager.java
+++ b/src/main/java/com/learnhive/lessonservice/auth/JwtTokenManager.java
@@ -1,0 +1,70 @@
+package com.learnhive.lessonservice.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Set;
+
+@Component
+public class JwtTokenManager {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.expirationTime}")
+    private long expirationTime;
+
+
+    public String generateToken(String username) {
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + expirationTime);
+
+        return Jwts.builder()
+                .setSubject(username)
+//                .claim("roles", roles)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getUsernameFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+//
+//    public Set<String> getRolesFromToken(String token) {
+//        Claims claims = Jwts.parser()
+//                .setSigningKey(secretKey)
+//                .parseClaimsJws(token)
+//                .getBody();
+//        return claims.get("roles", Set.class);
+//    }
+
+    public Instant getExpirationDateFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getExpiration().toInstant();
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/auth/TokenProperties.java
+++ b/src/main/java/com/learnhive/lessonservice/auth/TokenProperties.java
@@ -1,0 +1,13 @@
+package com.learnhive.lessonservice.auth;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class TokenProperties {
+
+    @Value("${token.cookie.name}")
+    private String cookieName;
+}

--- a/src/main/java/com/learnhive/lessonservice/config/SecurityConfig.java
+++ b/src/main/java/com/learnhive/lessonservice/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.learnhive.lessonservice.config;
+
+import com.learnhive.lessonservice.auth.JwtAuthenticationFilter;
+import com.learnhive.lessonservice.auth.JwtTokenManager;
+import com.learnhive.lessonservice.auth.TokenProperties;
+import com.learnhive.lessonservice.service.JwtBlacklistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserDetailsService userDetailsService;
+    private final JwtTokenManager jwtUtil;
+    private final JwtBlacklistService jwtBlacklistService;
+    private final TokenProperties tokenProperties;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/users/signUp", "/api/users/signIn", "api/users/username").permitAll()
+                        .anyRequest().authenticated()
+                ).addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService, jwtBlacklistService, tokenProperties),
+                        UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http
+                .getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder())
+                .and()
+                .build();
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/config/SwaggerConfig.java
+++ b/src/main/java/com/learnhive/lessonservice/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.learnhive.lessonservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Learnhive - API Documentation")
+                        .version("1.0")
+                        .description("API documentation with JWT authentication"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .name("bearerAuth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+
+}

--- a/src/main/java/com/learnhive/lessonservice/controller/UserAccountController.java
+++ b/src/main/java/com/learnhive/lessonservice/controller/UserAccountController.java
@@ -1,0 +1,120 @@
+package com.learnhive.lessonservice.controller;
+
+import com.learnhive.lessonservice.auth.JwtTokenManager;
+import com.learnhive.lessonservice.auth.TokenProperties;
+import com.learnhive.lessonservice.domain.UserAccount;
+import com.learnhive.lessonservice.dto.UserAccountDto;
+import com.learnhive.lessonservice.service.JwtBlacklistService;
+import com.learnhive.lessonservice.service.JwtValidationService;
+import com.learnhive.lessonservice.service.UserAccountService;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/users")
+public class UserAccountController {
+
+    private final UserAccountService userService;
+    private final JwtTokenManager jwtUtil;
+    private final JwtValidationService jwtValidationService;
+    private final JwtBlacklistService jwtBlacklistService;
+
+    @PostMapping("/signUp")
+    public ResponseEntity<String> signUp(@Valid @RequestBody UserAccountDto userForm, BindingResult result) {
+        // 유효성 검증 실패 시
+        if (result.hasErrors()) {
+            return ResponseEntity.badRequest().body(result.getAllErrors().stream()
+                    .map(ObjectError::getDefaultMessage).collect(Collectors.joining(", ")));
+        }
+
+        // 유효성 검증 성공 시
+        UserAccount user = userService.signUp(userForm);
+        return ResponseEntity.ok("회원가입이 완료되었습니다. 사용자명: " + user.getUsername());
+    }
+
+    @PostMapping("/signIn")
+    public ResponseEntity<String> signIn(@RequestParam String username,
+                                         @RequestParam String password,
+                                         @RequestParam(required = false) boolean useCookie,
+                                         HttpServletResponse response) throws AuthenticationException {
+        try {
+            // 로그인 처리 및 토큰 발급
+            String token = userService.signIn(username, password, useCookie, response);
+
+            if (useCookie) {
+                // 쿠키에 토큰을 저장
+                return ResponseEntity.ok("Token stored in Cookie: " + token);
+            } else {
+                // 헤더에 토큰을 저장
+                return ResponseEntity.ok()
+                        .header("Authorization", "Bearer " + token)
+                        .body("Token returned in Authorization header: " + token);
+            }
+
+        } catch (AuthenticationException e) {
+            if (e instanceof UsernameNotFoundException) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 계정이 존재하지 않습니다. 입력하신 내용을 다시 확인해주세요.");
+            }
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("아이디 또는 비밀번호가 잘못되었습니다. 다시 시도해주세요.");
+        }
+    }
+
+    // 현재 사용 중인 토큰만 무효화하면서 로그아웃
+    @PostMapping("/signOut") // 로그인한 사람만 접근 가능
+    public ResponseEntity<String> signOut(@RequestParam Long userId, HttpServletResponse response) {
+        userService.signOut(userId, response);
+        return ResponseEntity.ok("현재 기기에서 로그아웃되었습니다.");
+    }
+
+    // 특정 토큰을 기준으로 다른 토큰들을 무효화하는 방식으로 모든 기기 로그아웃
+    @PostMapping("/signOut-all")
+    public ResponseEntity<String> signOutAll(@Parameter(description = "직접 토큰 입력 가능") @RequestParam(required = false) String requestToken,
+                                             HttpServletRequest request, HttpServletResponse response) {
+
+        String token = requestToken != null ? requestToken : jwtValidationService.extractToken(request);
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            jwtBlacklistService.blacklistToken(token); // 토큰을 블랙리스트에 추가
+            jwtValidationService.clearTokenCookie(response); // 쿠키에서 토큰 삭제
+            return ResponseEntity.ok("모든 기기에서 로그아웃되었습니다.");
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("사용한 토큰이 유효하지 않습니다.");
+        }
+    }
+
+    @GetMapping("/username")
+    public ResponseEntity<String> getUsernameByEmail(@Parameter(description = "조회를 원하는 유저 이메일", required = true)
+                                                     @RequestParam String email) {
+        String usernameByEmail = userService.findUsernameByEmail(email);
+        return ResponseEntity.ok("조회 결과: " + usernameByEmail);
+    }
+
+    @PutMapping("/{userId}")
+    public ResponseEntity<String> updateUser(@Parameter(description = "정보를 변경할 유저 아이디", required = true)
+                                             @PathVariable Long userId,
+                                             @RequestBody UserAccountDto updateForm) {
+        userService.updateUser(userId, updateForm);
+        return ResponseEntity.ok("사용자 정보 업데이트가 완료되었습니다.");
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> deleteUser(@Parameter(description = "삭제할 유저 아이디", required = true)
+                                             @PathVariable Long userId,
+                                             HttpServletResponse response) {
+        userService.deleteUser(userId, response);
+        return ResponseEntity.ok("아이디를 성공적으로 삭제했습니다.");
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/domain/AuditingFields.java
+++ b/src/main/java/com/learnhive/lessonservice/domain/AuditingFields.java
@@ -1,0 +1,28 @@
+package com.learnhive.lessonservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/learnhive/lessonservice/domain/JwtBlacklist.java
+++ b/src/main/java/com/learnhive/lessonservice/domain/JwtBlacklist.java
@@ -1,0 +1,28 @@
+package com.learnhive.lessonservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class JwtBlacklist extends AuditingFields{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private LocalDateTime expirationTime;
+
+}

--- a/src/main/java/com/learnhive/lessonservice/domain/UserAccount.java
+++ b/src/main/java/com/learnhive/lessonservice/domain/UserAccount.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class UserAccount extends AuditingFields{
+public class UserAccount extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/learnhive/lessonservice/domain/UserAccount.java
+++ b/src/main/java/com/learnhive/lessonservice/domain/UserAccount.java
@@ -1,0 +1,39 @@
+package com.learnhive.lessonservice.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class UserAccount extends AuditingFields{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @JsonIgnore
+    @Column(nullable = false)
+    private String userPassword;
+
+    @JsonIgnore
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @UpdateTimestamp
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime lastLogin;
+
+    private boolean isDeleted = false;
+}

--- a/src/main/java/com/learnhive/lessonservice/dto/UserAccountDto.java
+++ b/src/main/java/com/learnhive/lessonservice/dto/UserAccountDto.java
@@ -1,0 +1,31 @@
+package com.learnhive.lessonservice.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserAccountDto {
+
+    @NotBlank(message = "사용자 이름은 필수입니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 32, message = "비밀번호는 8자 이상 32자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,32}$",
+            message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String userPassword;
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효하지 않은 이메일 형식입니다.")
+    private String email;
+
+}

--- a/src/main/java/com/learnhive/lessonservice/exception/CustomException.java
+++ b/src/main/java/com/learnhive/lessonservice/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.learnhive.lessonservice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public CustomException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/exception/ExceptionCode.java
+++ b/src/main/java/com/learnhive/lessonservice/exception/ExceptionCode.java
@@ -1,0 +1,23 @@
+package com.learnhive.lessonservice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "사용자가 인증되지 않았습니다."),
+
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 이메일은 이미 사용 중입니다."),
+    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 사용자명은 이미 사용 중입니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 사용자를 찾을 수 없습니다."),
+
+    FORBIDDEN_ACTION(HttpStatus.FORBIDDEN, "요청하신 작업을 수행할 권한이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/learnhive/lessonservice/exception/ExceptionController.java
+++ b/src/main/java/com/learnhive/lessonservice/exception/ExceptionController.java
@@ -1,0 +1,27 @@
+package com.learnhive.lessonservice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException e) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        return ResponseEntity
+                .status(exceptionCode.getHttpStatus())
+                .body(new ExceptionResponse(exceptionCode.getMessage(), exceptionCode));
+    }
+
+    @AllArgsConstructor
+    public static class ExceptionResponse {
+        private String message;
+        private ExceptionCode exceptionCode;
+    }
+
+}

--- a/src/main/java/com/learnhive/lessonservice/exception/ExceptionController.java
+++ b/src/main/java/com/learnhive/lessonservice/exception/ExceptionController.java
@@ -1,12 +1,15 @@
 package com.learnhive.lessonservice.exception;
 
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.Getter;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-@Slf4j
+import java.util.stream.Collectors;
+
 @ControllerAdvice
 public class ExceptionController {
 
@@ -18,7 +21,17 @@ public class ExceptionController {
                 .body(new ExceptionResponse(exceptionCode.getMessage(), exceptionCode));
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessages = e.getBindingResult().getAllErrors().stream()
+                .map(ObjectError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return ResponseEntity
+                .badRequest().body(errorMessages);
+    }
+
     @AllArgsConstructor
+    @Getter
     public static class ExceptionResponse {
         private String message;
         private ExceptionCode exceptionCode;

--- a/src/main/java/com/learnhive/lessonservice/repository/JwtBlacklistRepository.java
+++ b/src/main/java/com/learnhive/lessonservice/repository/JwtBlacklistRepository.java
@@ -1,0 +1,10 @@
+package com.learnhive.lessonservice.repository;
+
+import com.learnhive.lessonservice.domain.JwtBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JwtBlacklistRepository extends JpaRepository<JwtBlacklist, Long> {
+    Optional<JwtBlacklist> findTopByUsernameOrderByCreatedAtDesc(String username);
+}

--- a/src/main/java/com/learnhive/lessonservice/repository/UserAccountRepository.java
+++ b/src/main/java/com/learnhive/lessonservice/repository/UserAccountRepository.java
@@ -1,0 +1,14 @@
+package com.learnhive.lessonservice.repository;
+
+import com.learnhive.lessonservice.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+
+    Optional<UserAccount> findByUsername(String username);
+    Optional<UserAccount> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/learnhive/lessonservice/service/JwtBlacklistService.java
+++ b/src/main/java/com/learnhive/lessonservice/service/JwtBlacklistService.java
@@ -1,0 +1,50 @@
+package com.learnhive.lessonservice.service;
+
+import com.learnhive.lessonservice.auth.JwtTokenManager;
+import com.learnhive.lessonservice.domain.JwtBlacklist;
+import com.learnhive.lessonservice.repository.JwtBlacklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class JwtBlacklistService {
+
+    private final JwtTokenManager jwtUtil;
+    private final JwtBlacklistRepository jwtBlacklistRepository;
+
+    // 특정 토큰을 블랙리스트에 추가하는 메소드
+    public void blacklistToken(String token) {
+        String username = jwtUtil.getUsernameFromToken(token);
+        Instant expirationTime = jwtUtil.getExpirationDateFromToken(token);
+
+        jwtBlacklistRepository.save(JwtBlacklist.builder()
+                .token(token)
+                .username(username)
+                .expirationTime(expirationTime.atZone(ZoneId.systemDefault()).toLocalDateTime())
+                .build());
+    }
+
+    // 현재 토큰을 사용할 수 있는지 검사하는 메소드
+    public boolean isTokenBlacklisted(String currentToken) {
+        // 해당 유저의 확인할 블랙리스트가 있는지 먼저 체크
+        String username = jwtUtil.getUsernameFromToken(currentToken);
+        Optional<JwtBlacklist> topBlacklistOptional = jwtBlacklistRepository.findTopByUsernameOrderByCreatedAtDesc(username);
+        if (topBlacklistOptional.isEmpty()) {
+            return false;
+        }
+
+        // 블랙리스트에 해당 유저가 사용한 토큰이 있는 경우
+        LocalDateTime currentTokenExpiration = jwtUtil.getExpirationDateFromToken(currentToken)
+                .atZone(ZoneId.systemDefault()).toLocalDateTime(); // 현재 토큰의 만료 시간 추출
+        LocalDateTime topBlacklistTokenCreatedAt = topBlacklistOptional.get().getCreatedAt(); // 블랙리스트 토큰이 생성된 시간 추출
+
+        // 현재 토큰 생성 시점이 가장 마지막 블랙리스트 토큰 생성 시점보다 먼저면 무효화
+        return currentTokenExpiration.minusHours(1).isBefore(topBlacklistTokenCreatedAt);
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/service/JwtValidationService.java
+++ b/src/main/java/com/learnhive/lessonservice/service/JwtValidationService.java
@@ -1,0 +1,51 @@
+package com.learnhive.lessonservice.service;
+
+import com.learnhive.lessonservice.auth.TokenProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtValidationService {
+
+    private final TokenProperties tokenProperties;
+
+    public String extractToken(HttpServletRequest request) {
+        String requestToken = request.getParameter("requestToken");
+        String bearerToken = request.getHeader("Authorization");
+        String cookieToken = extractTokenFromCookies(request);
+
+        if (requestToken != null) {
+            return requestToken;
+        } else if (cookieToken != null) {
+            return cookieToken;
+        } else if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(tokenProperties.getCookieName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public void clearTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(tokenProperties.getCookieName(), null); // 토큰을 지운 쿠키 반환
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // HTTPS일 경우 true로 설정
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/learnhive/lessonservice/service/UserAccountService.java
+++ b/src/main/java/com/learnhive/lessonservice/service/UserAccountService.java
@@ -1,0 +1,169 @@
+package com.learnhive.lessonservice.service;
+
+
+import com.learnhive.lessonservice.auth.AuthenticatedUserService;
+import com.learnhive.lessonservice.auth.JwtTokenManager;
+import com.learnhive.lessonservice.auth.TokenProperties;
+import com.learnhive.lessonservice.domain.UserAccount;
+import com.learnhive.lessonservice.dto.UserAccountDto;
+import com.learnhive.lessonservice.exception.CustomException;
+import com.learnhive.lessonservice.exception.ExceptionCode;
+import com.learnhive.lessonservice.repository.UserAccountRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class UserAccountService {
+
+    private final UserAccountRepository userAccountRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final UserDetailsService userDetailsService;
+    private final JwtTokenManager jwtUtil;
+    private final TokenProperties tokenProperties;
+    private final AuthenticatedUserService authenticatedUserService;
+    private final JwtValidationService jwtValidationService;
+
+    @Transactional
+    public UserAccount signUp(UserAccountDto userAccountDto) {
+        // 이메일 중복 확인
+        if (userAccountRepository.existsByEmail(userAccountDto.getEmail())) {
+            throw new CustomException(ExceptionCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        // 사용자명 중복 확인
+        if (userAccountRepository.existsByEmail(userAccountDto.getUsername())) {
+            throw new CustomException(ExceptionCode.USERNAME_ALREADY_EXISTS);
+        }
+
+        // User 객체 생성 및 저장
+        UserAccount userAccount = UserAccount.builder()
+                .username(userAccountDto.getUsername())
+                .userPassword(passwordEncoder.encode(userAccountDto.getUserPassword()))
+                .email(userAccountDto.getEmail())
+                .build();
+
+        return userAccountRepository.save(userAccount);
+    }
+
+    @Transactional
+    public String signIn(String username, String password,
+                         boolean useCookie, HttpServletResponse response) {
+        // 사용자 인증 처리 및 정보 로드
+        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        // 로그인 처리 후 정보 업데이트
+        UserAccount userAccount = userAccountRepository.findByUsername(userDetails.getUsername())
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        userAccount.setLastLogin(LocalDateTime.now());
+        userAccountRepository.save(userAccount);
+//
+//        // 인증된 사용자의 roles 변환
+//        Set<String> roles = userDetails.getAuthorities().stream()
+//                .map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
+
+        // 인증된 사용자 정보를 사용해 토큰 생성 및 저장
+        String token = jwtUtil.generateToken(userDetails.getUsername());
+
+        // 쿠키 사용시 토큰을 쿠키에 저장해서 반환
+        if (useCookie) {
+            Cookie cookie = new Cookie(tokenProperties.getCookieName(), token);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(false);
+            cookie.setPath("/");
+            cookie.setMaxAge(60 * 60);
+            response.addCookie(cookie);
+        }
+
+        return token;
+    }
+
+    @Transactional
+    public void signOut(Long userId, HttpServletResponse response) {
+        // 현재 인증된 사용자 가져오기
+        UserAccount authenticatedUser = authenticatedUserService.getAuthenticatedUser();
+
+        // 현재 인증된 사용자 아이디와 삭제 요청한 계정 아이디가 같은지 확인
+        if (!Objects.equals(userId, authenticatedUser.getUserId())) { // 객체 비교 사용해서 null 반환 없이 false 반환 유도
+            throw new CustomException(ExceptionCode.FORBIDDEN_ACTION);
+        }
+
+        // 쿠키 무효화
+        jwtValidationService.clearTokenCookie(response);
+    }
+
+    @Transactional
+    public void updateUser(Long userId, UserAccountDto updateForm) {
+        // 현재 인증된 사용자 가져오기
+        UserAccount authenticatedUser = authenticatedUserService.getAuthenticatedUser();
+
+        // 현재 인증된 사용자 아이디와 정보 변경 요청한 계정 아이디가 같은지 확인
+        if (!Objects.equals(userId, authenticatedUser.getUserId())) { // 객체 비교 사용해서 null 반환 없이 false 반환 유도
+            throw new CustomException(ExceptionCode.FORBIDDEN_ACTION);
+        }
+
+        // 회원 정보 수정
+        if (updateForm.getUsername() != null && authenticatedUser.getUsername().equals(updateForm.getUsername())) {
+            if (userAccountRepository.existsByUsername(updateForm.getUsername())) {
+                throw new CustomException(ExceptionCode.USERNAME_ALREADY_EXISTS);
+            }
+            authenticatedUser.setUsername(updateForm.getUsername());
+        }
+        if (updateForm.getEmail() != null && authenticatedUser.getEmail().equals(updateForm.getEmail())) {
+            if (userAccountRepository.existsByEmail(updateForm.getEmail())) {
+                throw new CustomException(ExceptionCode.EMAIL_ALREADY_EXISTS);
+            }
+            authenticatedUser.setEmail(updateForm.getEmail());
+        }
+        if (updateForm.getUserPassword() != null) {
+            if (userAccountRepository.existsByUsername(updateForm.getUsername())) {
+                authenticatedUser.setUserPassword(passwordEncoder.encode(updateForm.getUserPassword()));
+            }
+        }
+
+        userAccountRepository.save(authenticatedUser);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId, HttpServletResponse response) {
+        // 현재 인증된 사용자 가져오기
+        UserAccount authenticatedUser = authenticatedUserService.getAuthenticatedUser();
+
+        // 현재 인증된 사용자 아이디와 삭제 요청한 계정 아이디가 같은지 확인
+        if (!Objects.equals(userId, authenticatedUser.getUserId())) { // 객체 비교 사용해서 null 반환 없이 false 반환 유도
+            throw new CustomException(ExceptionCode.FORBIDDEN_ACTION);
+        }
+
+        // 소프트 삭제 처리
+        authenticatedUser.setDeleted(true);
+        userAccountRepository.save(authenticatedUser);
+        jwtValidationService.clearTokenCookie(response);
+    }
+
+    public String findUsernameByEmail(String email) {
+        UserAccount userAccount = userAccountRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+
+        // 계정이 삭제되었는지 확인 (soft delete 처리된 계정 차단)
+        if (userAccount.isDeleted()) {
+            return "계정이 존재하지 않습니다.";
+        }
+        return userAccount.getUsername();
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,13 @@
+# MySQL
+spring.datasource.url=jdbc:mysql://localhost:3306/dev_db
+spring.datasource.username=dev_user
+spring.datasource.password=dev_password
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+
+# JWT
+jwt.secretKey=devSecretKey123
+jwt.expirationTime=3600000
+token.cookie.name=dev_token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=lesson-service
+
+# common configuration
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# active profile
+spring.profiles.active=prod

--- a/src/test/java/com/learnhive/lessonservice/LessonServiceApplicationTests.java
+++ b/src/test/java/com/learnhive/lessonservice/LessonServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.learnhive.lesson_service;
+package com.learnhive.lessonservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
**변경 사항**
- MySQL 서버 설정 및 인증 관련 기능 의존성을 추가했습니다.
- 회원 계정 CRUD 기능을 추가했습니다.
- Spring Security 사용해서 인증 정보를 로드할 수 있도록 설정했습니다.
- 서버 부담을 감소하고 확장성을 높이기 위해 토큰 기반 인증 방식으로 구현했습니다.
- 사용자 환경에 맞는 인증 방식을 제공할 수 있도록 헤더와 쿠키 저장 옵션을 제공했습니다.

**참고 사항**
- 유저 계정에 역할 분류 기능이 추가되지 않은 상태입니다.
- 유저 계정 삭제에 소프트 삭제를 적용하면서 isDeleted 필드가 추가되었습니다.
- 가입시 이메일 인증 기능이 추가되지 않은 상태입니다.
- Swagger를 통해 API 테스트가 가능합니다.